### PR TITLE
Add pytest matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ easier on the human brain.
 
 This package is a plug-in for `pytest` and works with Python 3.9 and up.
 
-- Tested with `pytest` version 7.4.x, should work with any version 6.2.5
-  or higher
+- Tested with `pytest` versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and
+  8.2. or higher
 - Tested with CPython 3.9-3.12 and PyPy 3.9-3.10
 
 While this code currently has a classifier of "Development Status :: 4 -

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ unittest = [
 ]
 
 [project.urls]
+"Documentation" = "https://pytest-scenario-files.mspex.net/"
 "Repository" = "https://github.com/paulsuh/pytest-scenario-files"
 "Issues" = "https://github.com/paulsuh/pytest-scenario-files/issues"
 "Changelog" = "https://github.com/paulsuh/pytest-scenario-files/blob/main/CHANGES.md"
@@ -102,6 +103,7 @@ dependencies = [
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
+pytest = ["8.1", "8.2"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     'Operating System :: OS Independent',
 ]
 dependencies = [
-    "pytest>=7.2.0",
+    "pytest>=7.0",
     "pyyaml"
 ]
 requires-python = ">=3.9"
@@ -92,7 +92,7 @@ check = "mypy --install-types --non-interactive {args:src/pytest_scenario_files 
 [tool.hatch.envs.test]
 dependencies = [
     "coverage[toml]>=6.5",
-    "pytest",
+    "pytest=={matrix:pytest}.*",
 ]
 
 [tool.hatch.envs.docs]
@@ -102,8 +102,17 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
-pytest = ["8.1", "8.2"]
+python = ["3.9", "3.10", "3.11", "pypy3.9", "pypy3.10"]
+pytest = ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.12"]
+pytest = ["7.3", "7.4", "8.0", "8.1", "8.2"]
+
+#[tool.hatch.envs.test.overrides]
+#matrix.pytest.dependencies = [
+#    { value = "pytest ~= {matrix:pytest}" },
+#]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Add `pytest` versions 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1, and 8.2 to the test matrix. Note the change in the README. 