### PR TITLE
31 psf responses needed even if no data element specified

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,9 @@ dependencies = [
     "coverage[toml]",
     "pytest",
     "ruff",
-    "sphinx"
+    "sphinx",
+    "responses",
+    "respx"
 ]
 python="3.11"
 

--- a/src/pytest_scenario_files/plugin.py
+++ b/src/pytest_scenario_files/plugin.py
@@ -418,27 +418,30 @@ def _extract_responses(
             for one_fixture_name in one_scenario.keys()
             if one_fixture_name.endswith("_response") or one_fixture_name.endswith("_responses")
         ]
-        psf_responses_data = []
-        for one_fixture_name in responses_fixture_names:
-            current_fixture_data = one_scenario.pop(one_fixture_name)
-            # TODO: once Python 3.9 is EOL, change this to the cleaner structural
-            #  pattern matching form.
-            # It's entirely possible that the contents of either the list
-            # or the dict are not usable, but that will be caught when the
-            # mocks are constructed.
-            if isinstance(current_fixture_data, list):
-                psf_responses_data.extend(current_fixture_data)
-            elif isinstance(current_fixture_data, dict):
-                psf_responses_data.append(current_fixture_data)
-            elif current_fixture_data is None:
-                pass
-            else:
-                raise RuntimeError(f"Pytest-Scenario-Files: {one_fixture_name} is not a list or dict.")
-        # It's possible to have a scenario where there are no responses, such
-        # as a case where a fixture is auto-used but the particular scenario
-        # doesn't actually make any HTTP calls so there's no need to mack anything
-        # so we need to put in a list even if the length is zero.
-        one_scenario[fixture_key] = psf_responses_data
+        # Need to differentiate between the case where responses are not specified
+        # at all and where there are only null responses
+        if len(responses_fixture_names) > 0:
+            psf_responses_data = []
+            for one_fixture_name in responses_fixture_names:
+                current_fixture_data = one_scenario.pop(one_fixture_name)
+                # TODO: once Python 3.9 is EOL, change this to the cleaner structural
+                #  pattern matching form.
+                # It's entirely possible that the contents of either the list
+                # or the dict are not usable, but that will be caught when the
+                # mocks are constructed.
+                if isinstance(current_fixture_data, list):
+                    psf_responses_data.extend(current_fixture_data)
+                elif isinstance(current_fixture_data, dict):
+                    psf_responses_data.append(current_fixture_data)
+                elif current_fixture_data is None:
+                    pass
+                else:
+                    raise RuntimeError(f"Pytest-Scenario-Files: {one_fixture_name} is not a list or dict.")
+            # It's possible to have a scenario where there are no responses, such
+            # as a case where a fixture is auto-used but the particular scenario
+            # doesn't actually make any HTTP calls so there's no need to mack anything
+            # so we need to put in a list even if the length is zero.
+            one_scenario[fixture_key] = psf_responses_data
 
     # at the end of this the fixture data dict has had all of the "_responses"
     # entries popped out of it and each scenario that has a "psf_responses_indirect" or

--- a/tests/pytester_example_files/data_psf_response_not_in_datafile_tester.yaml
+++ b/tests/pytester_example_files/data_psf_response_not_in_datafile_tester.yaml
@@ -1,0 +1,9 @@
+test_one:
+  input_data_1: 19
+  input_data_2: 17
+  expected_result: 36
+
+test_two:
+  input_data_1: "blah"
+  input_data_2: "blah"
+  expected_result: "blahblah"

--- a/tests/pytester_example_files/example_test_psf_response_not_in_datafile_tester.py
+++ b/tests/pytester_example_files/example_test_psf_response_not_in_datafile_tester.py
@@ -1,0 +1,2 @@
+def test_psf_response_not_in_datafile_tester(input_data_1, input_data_2, expected_result):
+    assert expected_result == input_data_1 + input_data_2

--- a/tests/success cases/test_psf_response_not_in_datafile.py
+++ b/tests/success cases/test_psf_response_not_in_datafile.py
@@ -1,0 +1,17 @@
+"""Load multiple test cases from one file.
+
+This also tests loading from a YAML file as well.
+"""
+
+
+def test_psf_response_not_in_datafile(pytester):
+    # create the test code file
+    test_file_path = pytester.copy_example("example_test_psf_response_not_in_datafile_tester.py")
+    test_file_path.rename("test_psf_response_not_in_datafile_tester.py")
+
+    # create the data file
+    pytester.copy_example("data_psf_response_not_in_datafile_tester.yaml")
+
+    result = pytester.runpytest("-k", "test_psf_response_not_in_datafile", "-v", "--psf-load-responses")
+
+    result.assert_outcomes(passed=2)

--- a/tests/success cases/test_psf_response_not_present.py
+++ b/tests/success cases/test_psf_response_not_present.py
@@ -1,6 +1,5 @@
-"""Load multiple test cases from one file.
-
-This also tests loading from a YAML file as well.
+"""Check for correct behavior when psf-load-responses flag is set
+but there is no '_responses' fixture specified in the data file.
 """
 
 


### PR DESCRIPTION
Fix bug where a psf_responses or psf_respx_mock fixture would be inserted even if none was specified. 